### PR TITLE
Use center of marker corners instead of cloud centroid.

### DIFF
--- a/ar_track_alvar/include/ar_track_alvar/filter/kinect_filtering.h
+++ b/ar_track_alvar/include/ar_track_alvar/filter/kinect_filtering.h
@@ -53,6 +53,7 @@
 #include <pcl/segmentation/sac_segmentation.h>
 #include <pcl_ros/point_cloud.h>
 #include <pcl/filters/extract_indices.h>
+#include <pcl/filters/project_inliers.h>
 #include <boost/lexical_cast.hpp>
 #include <Eigen/StdVector>
 
@@ -81,6 +82,9 @@ ARCloud::Ptr filterCloud (const ARCloud& cloud,
 
 // Wrapper for PCL plane fitting
 PlaneFitResult fitPlane (ARCloud::ConstPtr cloud);
+
+// Project cloud in plane
+ARCloud::Ptr projectCloudInPlane(ARCloud::ConstPtr cloud, pcl::ModelCoefficients::ConstPtr plane_coeffs);
 
 // Given the coefficients of a plane, and two points p1 and p2, we produce a 
 // quaternion q that sends p2'-p1' to (1,0,0) and n to (0,0,1), where p1' and

--- a/ar_track_alvar/src/kinect_filtering.cpp
+++ b/ar_track_alvar/src/kinect_filtering.cpp
@@ -75,6 +75,18 @@ namespace ar_track_alvar
     return res;
   }
 
+  ARCloud::Ptr projectCloudInPlane(ARCloud::ConstPtr cloud, pcl::ModelCoefficients::ConstPtr plane_coeffs) {
+    ARCloud::Ptr projected_cloud(new ARCloud());
+
+    pcl::ProjectInliers<ARPoint> proj;
+    proj.setModelType(pcl::SACMODEL_PLANE);
+    proj.setInputCloud(cloud);
+    proj.setModelCoefficients(plane_coeffs);
+    proj.filter(*projected_cloud);
+
+    return projected_cloud;
+  }
+
   ARCloud::Ptr filterCloud (const ARCloud& cloud, const vector<cv::Point, Eigen::aligned_allocator<cv::Point> >& pixels)
   {
     ARCloud::Ptr out(new ARCloud());


### PR DESCRIPTION
This PR changes the way marker poses are calculated: instead of using the centroid of the inlier marker points, it uses the center of the four marker corners.