### PR TITLE
Fix static build if findMarkerBundles linked to the new rosbag plugin library librosbag_default_encryption_plugins.so

### DIFF
--- a/ar_track_alvar/CMakeLists.txt
+++ b/ar_track_alvar/CMakeLists.txt
@@ -134,7 +134,7 @@ target_link_libraries(trainMarkerBundle ar_track_alvar ${catkin_LIBRARIES})
 add_dependencies(trainMarkerBundle ${PROJECT_NAME}_gencpp ${GENCPP_DEPS})
 
 add_executable(findMarkerBundles nodes/FindMarkerBundles.cpp)
-target_link_libraries(findMarkerBundles ar_track_alvar kinect_filtering medianFilter ${catkin_LIBRARIES})
+target_link_libraries(findMarkerBundles kinect_filtering medianFilter ar_track_alvar ${catkin_LIBRARIES})
 add_dependencies(findMarkerBundles ${PROJECT_NAME}_gencpp ${GENCPP_DEPS})
 
 add_executable(findMarkerBundlesNoKinect nodes/FindMarkerBundlesNoKinect.cpp)


### PR DESCRIPTION
`catkin_LIBRARIES` already lists plugin library `librosbag_default_encryption_plugins.so` with flags to include all symbols (https://github.com/Intermodalics/ros-intermodalics/pull/4).

Because `ar_track_alvar`, `kinect_filtering` and `medianFilter` link to `${catkin_LIBRARIES}` independently, and `findMarkerBundles` linked to `ar_track_alvar`, `kinect_filtering`
and `medianFilter`, cmake was adding all libraries from `${catkin_LIBRARIES}`
twice. This triggered linker errors due to duplicate symbols.

The solution is to always list `${catkin_LIBRARIES}` last and preserve the dependency order in all `target_link_libraries()` commands.